### PR TITLE
Use right element to get LitElement from

### DIFF
--- a/dist/pvpc-hourly-pricing-card.js
+++ b/dist/pvpc-hourly-pricing-card.js
@@ -1,5 +1,5 @@
 const LitElement =
-  window.LitElement || Object.getPrototypeOf(customElements.get('home-assistant') || customElements.get('hui-view'));
+  window.LitElement || Object.getPrototypeOf(customElements.get("ha-panel-lovelace") || customElements.get("hc-lovelace"));
 const { html, css } = LitElement.prototype;
 
 const locale = {


### PR DESCRIPTION
`home-assistant` and `hui-view` both don't have LitElement as prototype.

Fixes https://github.com/danimart1991/pvpc-hourly-pricing-card/issues/29