### PR TITLE
Sort keys to allow sensor with unordered attributes

### DIFF
--- a/dist/pvpc-hourly-pricing-card.js
+++ b/dist/pvpc-hourly-pricing-card.js
@@ -680,10 +680,10 @@ class PVPCHourlyPricingCard extends LitElement {
     const priceRegex = /price_\d\dh/;
     const priceNextDayRegex = /price_(next|last)_day_\d\dh/;
 
-    const priceArray = Object.keys(attributes)
+    const priceArray = Object.keys(attributes).sort()
       .filter((key) => priceRegex.test(key))
       .map((key) => attributes[key]);
-    const priceNextDayArray = Object.keys(attributes)
+    const priceNextDayArray = Object.keys(attributes).sort()
       .filter((key) => priceNextDayRegex.test(key))
       .map((key) => attributes[key]);
 


### PR DESCRIPTION
Add sort to attribute keys to allow using it with template sensors that don't keep attributes ordered as the for loop expects.