### PR TITLE
Corrección de la visualización de precios del día siguiente

### DIFF
--- a/dist/pvpc-hourly-pricing-card.js
+++ b/dist/pvpc-hourly-pricing-card.js
@@ -485,10 +485,11 @@ class PVPCHourlyPricingCard extends LitElement {
     const maxIndex = this.despiction.maxIndex;
     const minIndexNextDay = this.despiction.minIndexNextDay;
     const maxIndexNextDay = this.despiction.maxIndexNextDay;
-    const hasNextDayData = this.despiction.pricesNextDay[0] !== undefined;
+    const hasNextDayData = this.despiction.pricesNextDay[0] !== undefined && this.despiction.pricesNextDay[0] !== null;
     const hasNextDayInjectionData =
       this.despictionInjection &&
-      this.despictionInjection.pricesNextDay[0] !== undefined;
+      this.despictionInjection.pricesNextDay[0] !== undefined && 
+      this.despictionInjection.pricesNextDay[0] !== null;
     const minIcon = "▼";
     const maxIcon = "▲";
 


### PR DESCRIPTION
El componente PVPC, en su versión custom, ha añadido soporte para tarifa indexada y ajuste de mercado. Sin embargo, yo personalmente he encontrado problemas con el sensor derivado de inyección. Ver aquí para más detalles: https://github.com/azogue/ha-pvpc-custom/issues/17

Así que he creado un sensor de plantilla haciendo el cálculo manualmente. Este es mi nuevo sensor:

```yaml
- sensor:
    - name: tarifa_indexada
      unit_of_measurement: "€/kWh"
      state: >
        {{ (states('sensor.pvpc') | float) - (states('sensor.market_adjustment') | float) }}
      attributes:
        state_class: measurement
        data_id: "{{ state_attr('sensor.pvpc', 'data_id') }}"
        period: "{{ state_attr('sensor.pvpc', 'period') }}"
        next_better_price: "{{ (state_attr('sensor.pvpc', 'next_better_price') | float - state_attr('sensor.market_adjustment', 'next_better_price') | float) | round(5) }}"
        hours_to_better_price: "{{ state_attr('sensor.pvpc', 'hours_to_better_price') }}"
        num_better_prices_ahead: "{{ state_attr('sensor.pvpc', 'num_better_prices_ahead') }}"
        price_position: "{{ state_attr('sensor.pvpc', 'price_position') }}"
        price_ratio: "{{ (state_attr('sensor.pvpc', 'price_ratio') | float - state_attr('sensor.market_adjustment', 'price_ratio') | float) | round(2) }}"
        max_price: "{{ (state_attr('sensor.pvpc', 'max_price') | float - state_attr('sensor.market_adjustment', 'max_price') | float) | round(5) }}"
        max_price_at: "{{ state_attr('sensor.pvpc', 'max_price_at') }}"
        min_price: "{{ (state_attr('sensor.pvpc', 'min_price') | float - state_attr('sensor.market_adjustment', 'min_price') | float) | round(5) }}"
        min_price_at: "{{ state_attr('sensor.pvpc', 'min_price_at') }}"
        price_00h: "{{ (state_attr('sensor.pvpc', 'price_00h') | float - state_attr('sensor.market_adjustment', 'price_00h') | float) | round(5) }}"
        price_01h: "{{ (state_attr('sensor.pvpc', 'price_01h') | float - state_attr('sensor.market_adjustment', 'price_01h') | float) | round(5) }}"
        price_02h: "{{ (state_attr('sensor.pvpc', 'price_02h') | float - state_attr('sensor.market_adjustment', 'price_02h') | float) | round(5) }}"
        price_03h: "{{ (state_attr('sensor.pvpc', 'price_03h') | float - state_attr('sensor.market_adjustment', 'price_03h') | float) | round(5) }}"
        price_04h: "{{ (state_attr('sensor.pvpc', 'price_04h') | float - state_attr('sensor.market_adjustment', 'price_04h') | float) | round(5) }}"
        price_05h: "{{ (state_attr('sensor.pvpc', 'price_05h') | float - state_attr('sensor.market_adjustment', 'price_05h') | float) | round(5) }}"
        price_06h: "{{ (state_attr('sensor.pvpc', 'price_06h') | float - state_attr('sensor.market_adjustment', 'price_06h') | float) | round(5) }}"
        price_07h: "{{ (state_attr('sensor.pvpc', 'price_07h') | float - state_attr('sensor.market_adjustment', 'price_07h') | float) | round(5) }}"
        price_08h: "{{ (state_attr('sensor.pvpc', 'price_08h') | float - state_attr('sensor.market_adjustment', 'price_08h') | float) | round(5) }}"
        price_09h: "{{ (state_attr('sensor.pvpc', 'price_09h') | float - state_attr('sensor.market_adjustment', 'price_09h') | float) | round(5) }}"
        price_10h: "{{ (state_attr('sensor.pvpc', 'price_10h') | float - state_attr('sensor.market_adjustment', 'price_10h') | float) | round(5) }}"
        price_11h: "{{ (state_attr('sensor.pvpc', 'price_11h') | float - state_attr('sensor.market_adjustment', 'price_11h') | float) | round(5) }}"
        price_12h: "{{ (state_attr('sensor.pvpc', 'price_12h') | float - state_attr('sensor.market_adjustment', 'price_12h') | float) | round(5) }}"
        price_13h: "{{ (state_attr('sensor.pvpc', 'price_13h') | float - state_attr('sensor.market_adjustment', 'price_13h') | float) | round(5) }}"
        price_14h: "{{ (state_attr('sensor.pvpc', 'price_14h') | float - state_attr('sensor.market_adjustment', 'price_14h') | float) | round(5) }}"
        price_15h: "{{ (state_attr('sensor.pvpc', 'price_15h') | float - state_attr('sensor.market_adjustment', 'price_15h') | float) | round(5) }}"
        price_16h: "{{ (state_attr('sensor.pvpc', 'price_16h') | float - state_attr('sensor.market_adjustment', 'price_16h') | float) | round(5) }}"
        price_17h: "{{ (state_attr('sensor.pvpc', 'price_17h') | float - state_attr('sensor.market_adjustment', 'price_17h') | float) | round(5) }}"
        price_18h: "{{ (state_attr('sensor.pvpc', 'price_18h') | float - state_attr('sensor.market_adjustment', 'price_18h') | float) | round(5) }}"
        price_19h: "{{ (state_attr('sensor.pvpc', 'price_19h') | float - state_attr('sensor.market_adjustment', 'price_19h') | float) | round(5) }}"
        price_20h: "{{ (state_attr('sensor.pvpc', 'price_20h') | float - state_attr('sensor.market_adjustment', 'price_20h') | float) | round(5) }}"
        price_21h: "{{ (state_attr('sensor.pvpc', 'price_21h') | float - state_attr('sensor.market_adjustment', 'price_21h') | float) | round(5) }}"
        price_22h: "{{ (state_attr('sensor.pvpc', 'price_22h') | float - state_attr('sensor.market_adjustment', 'price_22h') | float) | round(5) }}"
        price_23h: "{{ (state_attr('sensor.pvpc', 'price_23h') | float - state_attr('sensor.market_adjustment', 'price_23h') | float) | round(5) }}"
        attribution: "Data derived from api.esios.ree.es by REE"
        icon: "mdi:flash"
        friendly_name: "Tarifa Indexada"
        max_price (next day): "{{ (state_attr('sensor.pvpc', 'max_price (next day)') | float - state_attr('sensor.market_adjustment', 'max_price (next day)') | float) | round(5) }}"
        max_price_at (next day): "{{ state_attr('sensor.pvpc', 'max_price_at (next day)') }}"
        min_price (next day): "{{ (state_attr('sensor.pvpc', 'min_price (next day)') | float - state_attr('sensor.market_adjustment', 'min_price (next day)') | float) | round(5) }}"
        min_price_at (next day): "{{ state_attr('sensor.pvpc', 'min_price_at (next day)') }}"
        price_next_day_00h: "{{ (state_attr('sensor.pvpc', 'price_next_day_00h') | float - state_attr('sensor.market_adjustment', 'price_next_day_00h') | float) | round(5) }}"
        price_next_day_01h: "{{ (state_attr('sensor.pvpc', 'price_next_day_01h') | float - state_attr('sensor.market_adjustment', 'price_next_day_01h') | float) | round(5) }}"
        price_next_day_02h: "{{ (state_attr('sensor.pvpc', 'price_next_day_02h') | float - state_attr('sensor.market_adjustment', 'price_next_day_02h') | float) | round(5) }}"
        price_next_day_03h: "{{ (state_attr('sensor.pvpc', 'price_next_day_03h') | float - state_attr('sensor.market_adjustment', 'price_next_day_03h') | float) | round(5) }}"
        price_next_day_04h: "{{ (state_attr('sensor.pvpc', 'price_next_day_04h') | float - state_attr('sensor.market_adjustment', 'price_next_day_04h') | float) | round(5) }}"
        price_next_day_05h: "{{ (state_attr('sensor.pvpc', 'price_next_day_05h') | float - state_attr('sensor.market_adjustment', 'price_next_day_05h') | float) | round(5) }}"
        price_next_day_06h: "{{ (state_attr('sensor.pvpc', 'price_next_day_06h') | float - state_attr('sensor.market_adjustment', 'price_next_day_06h') | float) | round(5) }}"
        price_next_day_07h: "{{ (state_attr('sensor.pvpc', 'price_next_day_07h') | float - state_attr('sensor.market_adjustment', 'price_next_day_07h') | float) | round(5) }}"
        price_next_day_08h: "{{ (state_attr('sensor.pvpc', 'price_next_day_08h') | float - state_attr('sensor.market_adjustment', 'price_next_day_08h') | float) | round(5) }}"
        price_next_day_09h: "{{ (state_attr('sensor.pvpc', 'price_next_day_09h') | float - state_attr('sensor.market_adjustment', 'price_next_day_09h') | float) | round(5) }}"
        price_next_day_10h: "{{ (state_attr('sensor.pvpc', 'price_next_day_10h') | float - state_attr('sensor.market_adjustment', 'price_next_day_10h') | float) | round(5) }}"
        price_next_day_11h: "{{ (state_attr('sensor.pvpc', 'price_next_day_11h') | float - state_attr('sensor.market_adjustment', 'price_next_day_11h') | float) | round(5) }}"
        price_next_day_12h: "{{ (state_attr('sensor.pvpc', 'price_next_day_12h') | float - state_attr('sensor.market_adjustment', 'price_next_day_12h') | float) | round(5) }}"
        price_next_day_13h: "{{ (state_attr('sensor.pvpc', 'price_next_day_13h') | float - state_attr('sensor.market_adjustment', 'price_next_day_13h') | float) | round(5) }}"
        price_next_day_14h: "{{ (state_attr('sensor.pvpc', 'price_next_day_14h') | float - state_attr('sensor.market_adjustment', 'price_next_day_14h') | float) | round(5) }}"
        price_next_day_15h: "{{ (state_attr('sensor.pvpc', 'price_next_day_15h') | float - state_attr('sensor.market_adjustment', 'price_next_day_15h') | float) | round(5) }}"
        price_next_day_16h: "{{ (state_attr('sensor.pvpc', 'price_next_day_16h') | float - state_attr('sensor.market_adjustment', 'price_next_day_16h') | float) | round(5) }}"
        price_next_day_17h: "{{ (state_attr('sensor.pvpc', 'price_next_day_17h') | float - state_attr('sensor.market_adjustment', 'price_next_day_17h') | float) | round(5) }}"
        price_next_day_18h: "{{ (state_attr('sensor.pvpc', 'price_next_day_18h') | float - state_attr('sensor.market_adjustment', 'price_next_day_18h') | float) | round(5) }}"
        price_next_day_19h: "{{ (state_attr('sensor.pvpc', 'price_next_day_19h') | float - state_attr('sensor.market_adjustment', 'price_next_day_19h') | float) | round(5) }}"
        price_next_day_20h: "{{ (state_attr('sensor.pvpc', 'price_next_day_20h') | float - state_attr('sensor.market_adjustment', 'price_next_day_20h') | float) | round(5) }}"
        price_next_day_21h: "{{ (state_attr('sensor.pvpc', 'price_next_day_21h') | float - state_attr('sensor.market_adjustment', 'price_next_day_21h') | float) | round(5) }}"
        price_next_day_22h: "{{ (state_attr('sensor.pvpc', 'price_next_day_22h') | float - state_attr('sensor.market_adjustment', 'price_next_day_22h') | float) | round(5) }}"
        price_next_day_23h: "{{ (state_attr('sensor.pvpc', 'price_next_day_23h') | float - state_attr('sensor.market_adjustment', 'price_next_day_23h') | float) | round(5) }}"
```

Sin embargo, esta plantilla tiene un problema difícil de corregir. Los precios del día siguiente, en el sensor original, sólo aparecen cuando hay un dato. Los sensores de plantilla de HA no pueden crearse con atributos dinámicos. De manera que en el sensor de plantilla los atributos para precios del siguiente día siempre están presentes, aunque valen "null" cuando no hay datos.

Esto es incompatbile con la tarjeta de Precios Horarios PVPC que lleva a que la tarjeta detecte la presencia de datos del día siguiente (mostrando el día en la leyenda) pero sin mostrar los datos correspondientes en el gráfico.

**Solución:**

Este pull request soluciona el problema ajustando la lógica utilizada para determinar la presencia de datos válidos de precios del día siguiente. Específicamente, se actualizó el método drawChart dentro de la clase PVPCHourlyPricingCard para verificar que los precios del día siguiente no solo estén presentes sino que también no sean null antes de intentar agregarlos al gráfico.

**Impacto:**

Este cambio no afecta a los usuarios actuales de la tarjeta ya que el cambio es compatible con ambas opciones.